### PR TITLE
Bump Ruby docker image from 2.7.0 to 3.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.0-alpine
+FROM ruby:3.2.2-alpine
 
 COPY LICENSE README.md /
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Support for Ruby 2.7 was [dropped][1] in bundler 2.5.0, released today (2023-12-15). We need bundler in this action. Therefore, we're bumping our Ruby version to a version that bundler supports, 3.2.2. This is also the most recent stable release of Ruby, and also the version of Ruby that we are currently using in the `commonlit` repo.

Discussed in Slack [here][2].

[Example][3] of a failing build:

```
#9 [5/5] RUN gem install bundler bundler-audit
#9 30.93 ERROR:  Error installing bundler:
#9 30.93 	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
#9 30.93 	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.0.0.
```

[1]: https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#250-december-15-2023
[2]: https://commonlit.slack.com/archives/C5BFTS7NC/p1702662411162479
[3]: https://github.com/commonlit/commonlit/actions/runs/7225260353/job/19688299101?pr=25786#step:2:130